### PR TITLE
19085 Enable focus request into webview

### DIFF
--- a/app/src/main/java/com/chartiq/chartiqsample/MainActivity.java
+++ b/app/src/main/java/com/chartiq/chartiqsample/MainActivity.java
@@ -134,6 +134,9 @@ public class MainActivity extends AppCompatActivity {
         createTalkbackFields();
         symbolInput.setText(defaultSymbol);
 
+        // Enable passing of focus requests into the webview
+        chartIQ.requestFocus(View.FOCUS_DOWN);
+
         chartIQ.setDataSource(new ChartIQ.DataSource() {
             @Override
             public void pullInitialData(Map<String, Object> params, ChartIQ.DataSourceCallback callback) {
@@ -613,6 +616,9 @@ public class MainActivity extends AppCompatActivity {
         drawingToolName.setText(drawingTool);
         drawingToolbar.setVisibility(View.VISIBLE);
         switch (drawingTool) {
+            case "Annotation":
+                chartIQ.enableDrawing("annotation");
+                break;
             case "Channel":
                 chartIQ.enableDrawing("channel");
                 break;

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -22,6 +22,7 @@
         <item>Point &amp; Figure</item>
     </string-array>
     <string-array name="drawing_tools">
+        <item>Annotation</item>
         <item>Channel</item>
         <item>Doodle</item>
         <item>Ellipse</item>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.1.1"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Aug 06 16:02:19 EDT 2018
+#Fri Aug 09 16:25:30 EDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Resolves ticket KB [19085](https://chartiq.kanbanize.com/ctrl_board/15/cards/19085/details/)

Enables passing of focus requests into the webview. Also adds the annotation drawing tool to the sample app.

To test, load up the sample app in Android Studio. Run the app in either the simulator or a physical device. 

- [x] Tap the drawing tool button in the bottom left corner. 
- [x] Verify that the annotation tool is available and select it.
- [x] Tap somewhere in the chart to begin annotation and verify that the keyboard appears and enters text in the input.